### PR TITLE
Add maven version to build output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ node('docker') {
         ]) {
             dir ('jenkins/core') {
                 /* Generate the minimal Maven site */
-                sh 'mvn -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
+                sh 'mvn --show-version -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
             }
 }    }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ node('docker') {
         ]) {
             dir ('jenkins/core') {
                 /* Generate the minimal Maven site */
-                sh 'mvn --show-version -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
+                sh 'mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
             }
 }    }
 


### PR DESCRIPTION
This can, and IMO should, be merged.

Incidentally, it will be helpful to understand https://github.com/jenkins-infra/core-taglibs-report-generator/pull/5 (which I cannot reproduce locally)