### PR TITLE
[JENKINS-50969] core site build is broken, needed for core taglibs reference

### DIFF
--- a/JENKINS-50969.patch
+++ b/JENKINS-50969.patch
@@ -1,0 +1,41 @@
+From 613f97abe0632fe60087d6d8de9c7942b10cfc9b Mon Sep 17 00:00:00 2001
+From: Baptiste Mathus <batmat@batmat.net>
+Date: Thu, 26 Apr 2018 15:52:14 +0200
+Subject: [PATCH] Manual reapply of
+ https://github.com/jenkinsci/jenkins/pull/3408 on 2.107
+
+---
+ pom.xml | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/pom.xml b/pom.xml
+index 3a297bea89..51a38fd3f0 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -104,6 +104,9 @@ THE SOFTWARE.
+ 
+     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
+ 
++    <!-- TODO: bump in parent pom and remove -->
++    <maven-site-plugin.version>3.7</maven-site-plugin.version>
++
+     <!-- Minimum Remoting version, which is tested for API compatibility -->
+     <remoting.version>3.17</remoting.version>
+     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
+@@ -536,13 +539,6 @@ THE SOFTWARE.
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-site-plugin</artifactId>
+-          <dependencies>
+-            <dependency>
+-              <groupId>org.kohsuke</groupId>
+-              <artifactId>doxia-module-markdown</artifactId>
+-              <version>1.0</version>
+-            </dependency>
+-          </dependencies>
+         </plugin>
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+-- 
+2.14.3
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ node('docker') {
         /* Checkout the latest LTS release so we don't need to build Jenkins to create the site */
         sh 'git clone https://github.com/jenkinsci/jenkins/ jenkins'
         dir ('jenkins') {
-            sh 'git checkout jenkins-2.46'
+            sh 'git checkout jenkins-2.107'
+            sh 'git apply ../JENKINS-50969.patch'
         }
 
         /* We only care about the taglib, so override index page and site descriptor */
@@ -33,9 +34,11 @@ node('docker') {
         ]) {
             dir ('jenkins/core') {
                 /* Generate the minimal Maven site */
-                sh 'mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
+                // FIXME: remove patching and forced site version when https://github.com/jenkinsci/jenkins/pull/3408 lands into next LTS
+                sh 'mvn --show-version --batch-mode  -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean org.apache.maven.plugins:maven-site-plugin:3.7:site'
             }
-}    }
+        }
+    }
 
     stage('Archive') {
         dir('jenkins/core/target/site') {

--- a/site/site.xml
+++ b/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.0</version>
+    <version>1.7</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50969

Manually apply https://github.com/jenkinsci/jenkins/pull/3408 for now at it's not in the LTS yet.