### PR TITLE
Build from latest LTS, not latest LTS baseline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node('docker&&linux') {
         deleteDir()
         checkout scm
 
-        def version = sh returnStdout: true, script: './determine-latest-lts-baseline.sh'
+        def version = sh returnStdout: true, script: './determine-latest-lts.sh'
         version = version.trim()
 
         /* Checkout the latest LTS release so we don't need to build Jenkins to create the site */

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -16,4 +16,4 @@ test_which curl
 test_which head
 test_which jq
 
-curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | jq --raw-output '.results[].version' | head -n 1
+curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | jq --raw-output '.results[].version' | head -n 1

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -16,4 +16,4 @@ test_which curl
 test_which head
 test_which jq
 
-curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | jq --raw-output '.results[].version' | head -n 1 | cut -d. -f1-2
+curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | jq --raw-output '.results[].version' | head -n 1


### PR DESCRIPTION
The Jenkins build for this repository is checking out 2.361 (the latest LTS baseline), not 2.361.1 (the latest LTS), which means we're still hitting the build bug that was fixed in LTS. This PR corrects the problem by using the latest LTS (2.361.1). I tested this by running the script locally.