### PR TITLE
Remove broken header icon

### DIFF
--- a/site/site.xml
+++ b/site/site.xml
@@ -1,8 +1,6 @@
 <project name="Jenkins">
   <bannerLeft>
-    <name>Jenkins</name>
-    <href>https://jenkins.io/</href>
-    <src>https://github.com/jenkins-infra/jenkins.io/raw/master/content/sites/default/files/images/headshot.png</src>
+    <name>Jenkins Taglib Documentation</name>
   </bannerLeft>
   <skin>
     <groupId>org.apache.maven.skins</groupId>

--- a/site/site.xml
+++ b/site/site.xml
@@ -1,6 +1,7 @@
 <project name="Jenkins">
   <bannerLeft>
     <name>Jenkins Taglib Documentation</name>
+    <href>https://jenkins.io/</href>
   </bannerLeft>
   <skin>
     <groupId>org.apache.maven.skins</groupId>


### PR DESCRIPTION
The published taglib documentation points to a broken image location, as we can see on https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html

The proposed change removes the icon in favor of a more descriptive title:
![Screenshot 2022-09-12 at 16 48 35](https://user-images.githubusercontent.com/13383509/189685083-c5586c9e-a462-4cae-9b52-52064692c911.png)

I considered using a working icon location, but I don't feel strongly about it, we don't have icons on javadocs either.