### PR TITLE
Move homepage URL

### DIFF
--- a/site/site.xml
+++ b/site/site.xml
@@ -1,7 +1,11 @@
 <project name="Jenkins">
+  <body>
+    <breadcrumbs>
+      <item name="Homepage" href="https://jenkins.io/" target="_blank"/>
+    </breadcrumbs>
+  </body>
   <bannerLeft>
     <name>Jenkins Taglib Documentation</name>
-    <href>https://jenkins.io/</href>
   </bannerLeft>
   <skin>
     <groupId>org.apache.maven.skins</groupId>


### PR DESCRIPTION
This is a follow-up PR to https://github.com/jenkins-infra/core-taglibs-report-generator/pull/17#discussion_r968541575, which moves the homepage URL to a nicer place:

![Screenshot 2022-09-12 at 22 40 08](https://user-images.githubusercontent.com/13383509/189754341-68d77178-5ed7-4876-b192-4837de9dae9f.png)