### PR TITLE
Update schedule to run on Thursdays

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
     /* Only keep the most recent builds. */
     buildDiscarder(logRotator(numToKeepStr: '20')),
     /* build regularly */
-    pipelineTriggers([cron('H H(18-23) * * 1')])
+    pipelineTriggers([cron('H H(18-23) * * 4')])
 ])
 
 


### PR DESCRIPTION
I just kicked off a build on trusted.ci because I wondered why the [taglib reference](https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html) referred to 2.375.3 still.
Figured, it runs on Monday for some reason, yet LTS releases take place on Wednesdays.

Let's adjust the schedule to run a day after the LTS release, to publish documentation changes timely, rather than delaying it by 5 days.