### PR TITLE
Remove automerge setting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     ":semanticCommitsDisabled",
     "schedule:earlyMondays"
   ],
-  "automerge": true,
   "reviewers": [
     "team:core"
   ],


### PR DESCRIPTION
Disable automerge, given there's no branch protection rule for PR reviews, renovate merges everything with a geen tick.