### PR TITLE
chore: replace `findFiles` by a shell script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,12 +57,17 @@ node('docker&&linux') {
         stage ('Publish') {
             dir('jenkins/core/target') {
                 sh 'mv -v site core-taglib'
-                def files = findFiles glob: 'core-taglib/**'
-                def filePaths = []
-                for (int i = 0; i < files.length; i++) {
-                    filePaths.add(files[i].path)
+                String[] files = sh(returnStdout: true, script: 'find core-taglib -type f -print0').split('\u0000')
+                // If there are matches
+                if (files[0] != '') {
+                    def filePaths = []
+                    for (int i = 0; i < files.length; i++) {
+                        filePaths.add(files[i].path)
+                    }
+                    infra.publishReports(filePaths)
+                } else {
+                    echo 'WARNING: no file found in core-taglib.'
                 }
-                infra.publishReports(filePaths)
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,9 @@ node('docker&&linux') {
         stage ('Publish') {
             dir('jenkins/core/target') {
                 sh 'mv -v site core-taglib'
+                // This script returns all filepaths separated by the null character (as they can contain white spaces)
                 String[] files = sh(returnStdout: true, script: 'find core-taglib -type f -print0').split('\u0000')
-                // If there are matches
+                // As the command above returns an array with one empty element if there is no match, check if it's not the case
                 if (files[0] != '') {
                     def filePaths = []
                     for (int i = 0; i < files.length; i++) {


### PR DESCRIPTION
Replace this function from the pipeline-utility-step plugin by a shell command, cf https://github.com/jenkins-infra/pipeline-library/issues/523#issuecomment-1324092257

(Thanks @jglick!)