### PR TITLE
fixup: convert array of strings to list for infra.publishReports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ node('docker&&linux') {
                 String[] files = sh(returnStdout: true, script: 'find core-taglib -type f -print0').split('\u0000')
                 // As the command above returns an array with one empty element if there is no match, check if it's not the case
                 if (files[0] != '') {
-                    infra.publishReports(files)
+                    infra.publishReports(files.toList())
                 } else {
                     echo 'WARNING: no file found in core-taglib.'
                 }


### PR DESCRIPTION
Fix the following error encountered with #28:
> hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: publishReports.call() is applicable for argument types: ([Ljava.lang.String;)

Fixup of #27 