### PR TITLE
Assemble page with Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,8 @@ node('docker&&linux') {
     stage('Generate') {
         withEnv([
                 "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk11'}",
-                "PATH+JAVA=${tool 'jdk11'}/bin"
+                "JAVA_HOME=${tool 'jdk17'}",
+                "PATH+JAVA=${tool 'jdk17'}/bin"
         ]) {
             dir ('jenkins/core') {
                 /* Generate the minimal Maven site */


### PR DESCRIPTION
The maven-fluido-skin pluin supports Java 17 out of the box, as verified by generating the Jelly taglib references for 2.401 on Java 17 and newer.
We don't need to stick to Java 11 anymore.