### PR TITLE
chore(Jenkinsfile) switch reports publication to credential-less

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ node('docker&&linux') {
                 String[] files = sh(returnStdout: true, script: 'find core-taglib -type f -print0').split('\u0000')
                 // As the command above returns an array with one empty element if there is no match, check if it's not the case
                 if (files[0] != '') {
-                    infra.publishReports(files.toList())
+                    infra.publishReports(files.toList(), [useWorkloadIdentity: true])
                 } else {
                     echo 'WARNING: no file found in core-taglib.'
                 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4925#issuecomment-3698617945

Same as https://github.com/jenkins-infra/repository-permissions-updater/pull/4860