### PR TITLE
Bump Java version to 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,8 @@ node('docker&&linux') {
     stage('Generate') {
         withEnv([
                 "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk17'}",
-                "PATH+JAVA=${tool 'jdk17'}/bin"
+                "JAVA_HOME=${tool 'jdk25'}",
+                "PATH+JAVA=${tool 'jdk25'}/bin"
         ]) {
             dir ('jenkins/core') {
                 /* Generate the minimal Maven site */


### PR DESCRIPTION
Ran `mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site` in core checking out 2.528.3.

Given we drop Java 17 soon, we can surely move on to 25.