### PR TITLE
chore: don't use any `tool` installers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 ])
 
 
-node('docker&&linux') {
+node('maven-25') {
 
     stage('Checkout') {
         /* Make sure we're always starting with a fresh workspace */
@@ -28,15 +28,9 @@ node('docker&&linux') {
     }
 
     stage('Generate') {
-        withEnv([
-                "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk25'}",
-                "PATH+JAVA=${tool 'jdk25'}/bin"
-        ]) {
-            dir ('jenkins/core') {
-                /* Generate the minimal Maven site */
-                sh 'mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
-            }
+        dir ('jenkins/core') {
+            /* Generate the minimal Maven site */
+            sh 'mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site'
         }
     }
 

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -9,7 +9,7 @@ function die() {
 	exit 1
 }
 
-wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
+curl --silent --fail --output jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
 chmod +x jq || die 'failed to make jq executable'
 curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | head -n 1
 

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -11,7 +11,8 @@ function die() {
 	exit 1
 }
 
-curl --silent --fail --output jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
+curl --silent --fail https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output jq || die 'failed to download jq'
+ls -al
 chmod +x jq || die 'failed to make jq executable'
 results="$(curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*')"
 versions="$(echo "${results}" | ./jq --raw-output '.results[].version')"

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+set -x
+
 function die() {
 	echo "$(basename "$0"): $*" >&2
 	exit 1
@@ -11,6 +13,8 @@ function die() {
 
 curl --silent --fail --output jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
 chmod +x jq || die 'failed to make jq executable'
-curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | head -n 1
+results="$(curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*')"
+versions="$(echo "${results}" | ./jq --raw-output '.results[].version')"
+echo "${versions}" | head -n 1
 
 exit 0


### PR DESCRIPTION
This change replaces the Maven and JDK `tool` installers by the use of a `maven-25` agent.

The part that uses installed `jq` (instead of downloading a v1.6 one with `wget` as those agents don't have it installed, and as the query is simple enough to be version independent) has been extracted to:
- #40

(In draft until merged)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5090#issuecomment-4389794022

### Testing done

Replay (Jenkinsfile only): https://trusted.ci.jenkins.io/job/core-taglibs-report-generator/527/