### PR TITLE
chore: use installed `jq` instead of downloading it with `wget`

### DIFF
--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -4,4 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Fail fast if `jq` is missing
+command -v jq 2>/dev/null || { echo "$(basename "$0"): 'jq' command not found."; exit 1; }
+
 curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | jq --raw-output '.results[].version' | head -n 1

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -9,7 +9,7 @@ function die() {
 	exit 1
 }
 
-wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
+curl --silent --fail --output jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
 chmod +x jq || die 'failed to make jq executable'
 curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | head -n 1
 

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -5,6 +5,6 @@ set -o nounset
 set -o pipefail
 
 # Fail fast if `jq` is missing
-command -v jq 2>/dev/null || { echo "$(basename "$0"): 'jq' command not found."; exit 1; }
+command -v jq 1>/dev/null  2>&1 || { echo "$(basename "$0"): 'jq' command not found."; exit 1; }
 
 curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | jq --raw-output '.results[].version' | head -n 1

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -4,13 +4,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function die() {
-	echo "$(basename "$0"): $*" >&2
-	exit 1
-}
-
-curl --silent --fail --output jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 || die 'failed to download jq'
-chmod +x jq || die 'failed to make jq executable'
-curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | head -n 1
-
-exit 0
+curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | jq --raw-output '.results[].version' | head -n 1

--- a/determine-latest-lts.sh
+++ b/determine-latest-lts.sh
@@ -5,6 +5,6 @@ set -o nounset
 set -o pipefail
 
 # Fail fast if `jq` is missing
-command -v jq 1>/dev/null  2>&1 || { echo "$(basename "$0"): 'jq' command not found."; exit 1; }
+command -v jq 1>/dev/null 2>&1 || { echo "$(basename "$0"): 'jq' command not found."; exit 1; }
 
 curl --silent --fail 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | jq --raw-output '.results[].version' | head -n 1


### PR DESCRIPTION
This change uses installed `jq` instead of downloading a v1.6 one with `wget` as `maven-25` agents that are used in #39 don't have it installed, and as the query is simple enough to be version independent

Extracted from:
- https://github.com/jenkins-infra/core-taglibs-report-generator/pull/39